### PR TITLE
Add frontend .env for dev API URL

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=http://localhost:8000/api


### PR DESCRIPTION
## Summary
- provide React API URL during development by adding `frontend/.env`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afd00dacc8330860dcd9716454b49