### PR TITLE
Remove console logs from LoginForm

### DIFF
--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -10,10 +10,8 @@ export default function LoginForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    console.log('Logging in with', email, password)
     try {
       const { token } = await login({ email, password })
-      console.log('Received token', token)
       localStorage.setItem('token', token)
       axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
       navigate('/dashboard')


### PR DESCRIPTION
## Summary
- remove console.log statements in LoginForm component

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afd0933308330858a48d9922f5ed3