### PR TITLE
Fix API URL in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfile
       args:
         # Арґумент, який CRA підхоплює при збірці
-        REACT_APP_API_URL: http://192.168.0.107:8000/api
+        REACT_APP_API_URL: http://api:80/api
     ports:
       - "3000:80"
     depends_on:


### PR DESCRIPTION
## Summary
- set the React API URL to use the `api` service name

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afd059f608330a235288085a2c353