### PR TITLE
Fix API URL for external Docker use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,6 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-      args:
-        # Арґумент, який CRA підхоплює при збірці
-        REACT_APP_API_URL: http://api:80/api
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,3 +27,7 @@ docker build -t komirka-frontend .
 docker run -p 3000:80 komirka-frontend
 ```
 The application is also included in `docker-compose.yml` and can be launched alongside the backend using `docker-compose up --build` from the repository root.
+
+When `REACT_APP_API_URL` is not provided during the build, the frontend will
+call the API at `http://<current-hostname>:8000/api`. To point it to a different
+address, supply the `REACT_APP_API_URL` build argument.

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,6 +1,11 @@
 import axios from 'axios'
 
-const API = process.env.REACT_APP_API_URL
+// Use build-time REACT_APP_API_URL if defined, otherwise fallback to the host
+// name from the browser to support running inside a VM where "api" is not a
+// resolvable domain outside the Docker network.
+const API =
+  process.env.REACT_APP_API_URL ||
+  `http://${window.location.hostname}:8000/api`
 
 export async function login({ email, password }) {
   const res = await axios.post(

--- a/frontend/src/api/bookings.js
+++ b/frontend/src/api/bookings.js
@@ -1,4 +1,8 @@
 import axios from 'axios';
-const API = process.env.REACT_APP_API_URL;
+
+// Fallback to the current host so API calls work outside the Docker network
+const API =
+  process.env.REACT_APP_API_URL ||
+  `http://${window.location.hostname}:8000/api`;
 
 export const createBooking = data => axios.post(`${API}/bookings`, data);

--- a/frontend/src/api/lockers.js
+++ b/frontend/src/api/lockers.js
@@ -1,6 +1,9 @@
 import axios from 'axios';
 
-const API = process.env.REACT_APP_API_URL;
+// Use current hostname if REACT_APP_API_URL is not provided
+const API =
+  process.env.REACT_APP_API_URL ||
+  `http://${window.location.hostname}:8000/api`;
 
 export async function fetchLockers() {
   const res = await axios.get(`${API}/lockers`);

--- a/frontend/src/api/payments.js
+++ b/frontend/src/api/payments.js
@@ -1,4 +1,8 @@
 import axios from 'axios';
-const API = process.env.REACT_APP_API_URL;
+
+// Resolve API endpoint based on current hostname when not provided via env var
+const API =
+  process.env.REACT_APP_API_URL ||
+  `http://${window.location.hostname}:8000/api`;
 
 export const pay = data => axios.post(`${API}/payments`, data);


### PR DESCRIPTION
## Summary
- let frontend fallback to hostname-based API URL when `REACT_APP_API_URL` isn't set
- remove API URL build arg from compose file
- document how the API URL is resolved in frontend README

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b031adcbc8330be2546a7eb6d87ed