### PR TITLE
Add locker filtering on map

### DIFF
--- a/backend/Controllers/LockersController.cs
+++ b/backend/Controllers/LockersController.cs
@@ -14,9 +14,28 @@ namespace KomirkaApp.Api.Controllers
 
         // GET /api/lockers
         [HttpGet]
-        public async Task<IActionResult> GetAll()
+        public async Task<IActionResult> GetAll(
+            [FromQuery] string? size,
+            [FromQuery] bool? video,
+            [FromQuery] bool? cooling,
+            [FromQuery] decimal? maxPrice)
         {
-            var list = await _db.Lockers.ToListAsync();
+            var query = _db.Lockers.AsQueryable();
+
+            if (!string.IsNullOrEmpty(size))
+                query = query.Where(l => l.Size == size);
+
+            if (video.HasValue)
+                query = query.Where(l => l.HasVideo == video.Value);
+
+            if (cooling.HasValue)
+                query = query.Where(l => l.HasCooling == cooling.Value);
+
+            if (maxPrice.HasValue)
+                query = query.Where(l => l.HourlyPrice <= maxPrice.Value ||
+                                         l.DailyPrice <= maxPrice.Value);
+
+            var list = await query.ToListAsync();
             return Ok(list);
         }
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,12 @@ REACT_APP_API_URL=http://localhost:5000/api npm start
 ```
 This runs the app in development mode on `http://localhost:3000`.
 
+## Map Filters
+The locker map now includes a filter panel allowing you to filter by size,
+additional services and maximum price. The React component issues GET requests
+with query parameters, so the backend must run the latest code from this
+repository.
+
 ## Building for Production
 ```bash
 npm run build

--- a/frontend/src/api/lockers.js
+++ b/frontend/src/api/lockers.js
@@ -5,7 +5,9 @@ const API =
   process.env.REACT_APP_API_URL ||
   `http://${window.location.hostname}:8000/api`;
 
-export async function fetchLockers() {
-  const res = await axios.get(`${API}/lockers`);
+export async function fetchLockers(params = {}) {
+  const query = new URLSearchParams(params).toString();
+  const url = `${API}/lockers${query ? `?${query}` : ''}`;
+  const res = await axios.get(url);
   return res.data;
 }

--- a/frontend/src/components/MapView.css
+++ b/frontend/src/components/MapView.css
@@ -1,4 +1,28 @@
+.map-wrapper {
+  position: relative;
+}
+
 .map-container {
-  height: calc(100vh - 60px); /* під NavBar */
+  height: calc(100vh - 60px);
   width: 100%;
+}
+
+.filter-container {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 8px;
+  border-radius: 4px;
+  z-index: 1000;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.filter-container select,
+.filter-container input,
+.filter-container button {
+  padding: 4px 6px;
+  font-size: 14px;
 }

--- a/frontend/src/components/MapView.js
+++ b/frontend/src/components/MapView.js
@@ -7,30 +7,76 @@ import './MapView.css';
 
 export default function MapView() {
   const [lockers, setLockers] = useState([]);
+  const [size, setSize] = useState('');
+  const [video, setVideo] = useState(false);
+  const [cooling, setCooling] = useState(false);
+  const [maxPrice, setMaxPrice] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetchLockers().then(setLockers).catch(console.error);
+    handleLoad();
   }, []);
 
+  const handleLoad = () => {
+    const params = {};
+    if (size) params.size = size;
+    if (video) params.video = true;
+    if (cooling) params.cooling = true;
+    if (maxPrice) params.maxPrice = maxPrice;
+    fetchLockers(params).then(setLockers).catch(console.error);
+  };
+
   return (
-    <MapContainer center={[50.45, 30.52]} zoom={12} className="map-container">
-      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      {lockers.map(l => (
-        <Marker key={l.id} position={[l.latitude, l.longitude]}>
-          <Popup>
-            <strong>{l.address}</strong>
-            <br />
-            Size: {l.size}
-            <br />
-            {l.hourlyPrice}$/h, {l.dailyPrice}$/day
-            <br />
-            {l.hasVideo && '📹 '} {l.hasCooling && '❄️ '}
-            <br />
-            <button onClick={() => navigate(`/booking/${l.id}`)}>Book</button>
-          </Popup>
-        </Marker>
-      ))}
-    </MapContainer>
+    <div className="map-wrapper">
+      <div className="filter-container">
+        <select value={size} onChange={e => setSize(e.target.value)}>
+          <option value="">All sizes</option>
+          <option value="S">S</option>
+          <option value="M">M</option>
+          <option value="L">L</option>
+        </select>
+        <label>
+          <input
+            type="checkbox"
+            checked={video}
+            onChange={e => setVideo(e.target.checked)}
+          />
+          Video
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={cooling}
+            onChange={e => setCooling(e.target.checked)}
+          />
+          Cooling
+        </label>
+        <input
+          type="number"
+          placeholder="Max price"
+          value={maxPrice}
+          onChange={e => setMaxPrice(e.target.value)}
+        />
+        <button onClick={handleLoad}>Apply</button>
+      </div>
+      <MapContainer center={[50.45, 30.52]} zoom={12} className="map-container">
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        {lockers.map(l => (
+          <Marker key={l.id} position={[l.latitude, l.longitude]}>
+            <Popup>
+              <strong>{l.address}</strong>
+              <br />
+              Size: {l.size}
+              <br />
+              {l.hourlyPrice}$/h, {l.dailyPrice}$/day
+              <br />
+              {l.hasVideo && '📹 '} {l.hasCooling && '❄️ '}
+              <br />
+              <button onClick={() => navigate(`/booking/${l.id}`)}>Book</button>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- support filtering lockers in API with query parameters
- expose filtering UI on the map
- add CSS for filter panel
- update README with instructions

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b08946a508330b517fb2ad4610bdc