### PR TITLE
Improve UI feedback and dashboard data

### DIFF
--- a/frontend/src/api/bookings.js
+++ b/frontend/src/api/bookings.js
@@ -6,3 +6,4 @@ const API =
   `http://${window.location.hostname}:8000/api`;
 
 export const createBooking = data => axios.post(`${API}/bookings`, data);
+export const getBookings = () => axios.get(`${API}/bookings`);

--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import axios from 'axios'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, Link } from 'react-router-dom'
 import { login, register } from '../api/auth'
+import Toast from './Toast'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './AuthForm.css'
 
@@ -10,14 +11,24 @@ export default function AuthForm() {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [success, setSuccess] = useState(false)
+  const [toast, setToast] = useState('')
+
+  useEffect(() => {
+    if (!toast) return
+    const id = setTimeout(() => setToast(''), 3000)
+    return () => clearTimeout(id)
+  }, [toast])
 
   const handleSubmit = async (e) => {
     e.preventDefault()
     try {
       if (mode === 'register') {
         await register({ email, password })
-        alert('Registration successful!')
-        navigate('/')
+        setSuccess(true)
+        setToast('Registration successful!')
+        setEmail('')
+        setPassword('')
       } else {
         const { token } = await login({ email, password })
         localStorage.setItem('token', token)
@@ -60,6 +71,14 @@ export default function AuthForm() {
       <button className="btn btn-link mt-3" onClick={() => navigate(mode === 'login' ? '/auth/register' : '/auth/login')}>
         {mode === 'login' ? 'Need an account? Register' : 'Have an account? Login'}
       </button>
+      {success && (
+        <div className="alert alert-success mt-3" role="alert">
+          Registration successful! You can now{' '}
+          <Link to="/auth/login" className="alert-link">log in</Link> or{' '}
+          <Link to="/lockers" className="alert-link">browse lockers</Link>.
+        </div>
+      )}
+      <Toast message={toast} onClose={() => setToast('')} />
     </div>
   )
 }

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,8 +1,17 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './Dashboard.css'
+import { getBookings } from '../api/bookings'
 
 export default function Dashboard() {
+  const [bookings, setBookings] = useState([])
+
+  useEffect(() => {
+    getBookings()
+      .then(res => setBookings(res.data))
+      .catch(console.error)
+  }, [])
+
   return (
     <div className="dashboard-container bg-white p-4 rounded shadow-sm mt-4">
       <h1 className="mb-3">Dashboard</h1>
@@ -10,6 +19,33 @@ export default function Dashboard() {
       <p>
         <a href="/lockers" className="link-primary">Browse available lockers</a>
       </p>
+      {bookings.length > 0 && (
+        <div className="table-responsive mt-4">
+          <h2 className="h5">All bookings</h2>
+          <table className="table table-sm">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Locker</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bookings.map(b => (
+                <tr key={b.id}>
+                  <td>{b.id}</td>
+                  <td>{b.lockerId}</td>
+                  <td>{new Date(b.startTime).toLocaleString()}</td>
+                  <td>{new Date(b.endTime).toLocaleString()}</td>
+                  <td>{b.price}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -1,5 +1,9 @@
 .landing-container {
   height: 100vh;
-  background: linear-gradient(135deg, #6B73FF 0%, #000DFF 100%);
+  background: linear-gradient(135deg, #74ebd5 0%, #ACB6E5 100%);
   color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }

--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+export default function Toast({ message, onClose }) {
+  useEffect(() => {
+    if (!message) return;
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [message, onClose]);
+
+  if (!message) return null;
+
+  return (
+    <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 11 }}>
+      <div className="toast show align-items-center text-bg-success border-0">
+        <div className="d-flex">
+          <div className="toast-body">{message}</div>
+          <button
+            type="button"
+            className="btn-close btn-close-white me-2 m-auto"
+            onClick={onClose}
+          ></button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show registration success on the page with next steps
- add toast component for bootstrap messages
- list all bookings on dashboard
- tweak landing page gradient

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf91b9588833087cf5f95a8908281