### PR TITLE
Expand dashboard with locker list

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,6 +23,10 @@ repository.
 The interface now uses Bootstrap 5 for styling. Marker icons on the map load
 properly thanks to an explicit Leaflet configuration.
 
+## Theme Toggle
+The UI now includes a light/dark mode switch in the navigation bar. The
+preference is saved in `localStorage` and applied on future visits.
+
 ## Building for Production
 ```bash
 npm run build

--- a/frontend/src/ThemeContext.js
+++ b/frontend/src/ThemeContext.js
@@ -1,0 +1,25 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export const ThemeContext = createContext({
+  theme: 'light',
+  toggle: () => {}
+});
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(
+    localStorage.getItem('theme') || 'light'
+  );
+
+  useEffect(() => {
+    document.body.classList.toggle('dark-theme', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/frontend/src/components/Dashboard.css
+++ b/frontend/src/components/Dashboard.css
@@ -1,5 +1,5 @@
 .dashboard-container {
-  max-width: 600px;
+  max-width: 900px;
   margin: 0 auto;
   text-align: center;
 }

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -2,13 +2,19 @@ import React, { useEffect, useState } from 'react'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './Dashboard.css'
 import { getBookings } from '../api/bookings'
+import { fetchLockers } from '../api/lockers'
 
 export default function Dashboard() {
   const [bookings, setBookings] = useState([])
+  const [lockers, setLockers] = useState([])
 
   useEffect(() => {
     getBookings()
       .then(res => setBookings(res.data))
+      .catch(console.error)
+
+    fetchLockers()
+      .then(data => setLockers(data))
       .catch(console.error)
   }, [])
 
@@ -19,6 +25,39 @@ export default function Dashboard() {
       <p>
         <a href="/lockers" className="link-primary">Browse available lockers</a>
       </p>
+      {lockers.length > 0 && (
+        <div className="table-responsive mt-4">
+          <h2 className="h5">Available lockers</h2>
+          <table className="table table-sm align-middle">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Address</th>
+                <th>Size</th>
+                <th>Hourly</th>
+                <th>Daily</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {lockers.map(l => (
+                <tr key={l.id}>
+                  <td>{l.id}</td>
+                  <td>{l.address}</td>
+                  <td>{l.size}</td>
+                  <td>{l.hourlyPrice}</td>
+                  <td>{l.dailyPrice}</td>
+                  <td>
+                    <a className="btn btn-sm btn-primary" href={`/booking/${l.id}`}>
+                      Book
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
       {bookings.length > 0 && (
         <div className="table-responsive mt-4">
           <h2 className="h5">All bookings</h2>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import { ThemeContext } from '../ThemeContext';
 
 export default function NavBar() {
+  const { theme, toggle } = useContext(ThemeContext);
+  const navbarClass = `navbar navbar-expand-lg mb-3 ${
+    theme === 'dark' ? 'navbar-dark bg-dark' : 'navbar-light bg-light'
+  }`;
+
   return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-light mb-3">
+    <nav className={navbarClass}>
       <div className="container">
         <Link className="navbar-brand" to="/">KomirkaApp</Link>
         <div className="collapse navbar-collapse">
@@ -19,6 +25,12 @@ export default function NavBar() {
               <Link className="nav-link" to="/dashboard">Dashboard</Link>
             </li>
           </ul>
+          <button
+            className="btn btn-outline-secondary ms-3"
+            onClick={toggle}
+          >
+            {theme === 'dark' ? 'Light' : 'Dark'} Mode
+          </button>
         </div>
       </div>
     </nav>

--- a/frontend/src/components/NavBar.test.js
+++ b/frontend/src/components/NavBar.test.js
@@ -1,12 +1,28 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import NavBar from './NavBar';
+import { ThemeProvider } from '../ThemeContext';
 
 test('shows links', () => {
   render(
     <BrowserRouter>
-      <NavBar />
+      <ThemeProvider>
+        <NavBar />
+      </ThemeProvider>
     </BrowserRouter>
   );
   expect(screen.getByText('Home')).toBeInTheDocument();
+});
+
+test('toggles theme', () => {
+  render(
+    <BrowserRouter>
+      <ThemeProvider>
+        <NavBar />
+      </ThemeProvider>
+    </BrowserRouter>
+  );
+  const button = screen.getByRole('button', { name: /dark mode/i });
+  fireEvent.click(button);
+  expect(button).toHaveTextContent(/light mode/i);
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,4 +6,9 @@ body {
   line-height: 1.4;
 }
 
+body.dark-theme {
+  background: #121212;
+  color: #f5f5f5;
+}
+
 a { text-decoration: none; }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { ThemeProvider } from './ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- show available lockers in Dashboard
- widen Dashboard layout for tables

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `dotnet test backend/Tests/Tests.csproj --no-build --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5613d29c8330b146284d8514523b